### PR TITLE
UF-14977: Extended service layer with logic to save chat history

### DIFF
--- a/src/integration-test/resources/AssistantIT/__files/test06_deleteSession/mappings/api-intric-get-assistant-session.json
+++ b/src/integration-test/resources/AssistantIT/__files/test06_deleteSession/mappings/api-intric-get-assistant-session.json
@@ -5,23 +5,15 @@
 				"equalTo": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE3NDEwNzg1MzQsImV4cCI6MTc0MTA4MjEzNCwiYXVkIjoid3d3Lml0dGVzdC5jb20iLCJzdWIiOiJpdHRlc3RAbm9yZXBseS5jb20ifQ.HQXOaHq4VNHpGxyfYKYOsSxpvScMgvqqhd702MlJ0YM"
 			}
 		},
-		"method": "POST",
-		"bodyPatterns": [
-			{
-				"equalToJson": {
-					"question": "Påbörjar session för party id '5a6c3e4e-c320-4006-b448-1fd4121df828'",
-					"files": []
-				}
-			}
-		],
-		"urlPath": "/intric/assistants/intric-assistant-uuid/sessions/"
+		"method": "GET",
+		"urlPath": "/intric/assistants/intric-assistant-uuid/sessions/158cfabe-1c3d-433c-b71f-1c909beaa291/"
 	},
 	"response": {
 		"headers": {
 			"Content-Type": "application/json"
 		},
 		"status": 200,
-		"bodyFileName": "test01_createSession/responses/api-intric-create-assistant-session-response.json"
+		"bodyFileName": "test06_deleteSession/responses/api-intric-get-assistant-session-response.json"
 	},
-	"name": "api-intric-create-assistant-session"
+	"name": "api-intric-get-assistant-session"
 }

--- a/src/integration-test/resources/AssistantIT/__files/test06_deleteSession/mappings/api-lime-save-chathistory.json
+++ b/src/integration-test/resources/AssistantIT/__files/test06_deleteSession/mappings/api-lime-save-chathistory.json
@@ -1,0 +1,107 @@
+{
+	"request": {
+		"headers": {
+			"X-Client-Secret": {
+				"equalTo": "lime-api-key"
+			}
+		},
+		"method": "POST",
+		"bodyPatterns": [
+			{
+				"equalToJson": {
+					"chatSession": {
+						"created_at": "2025-03-07T07:05:58.727118Z",
+						"updated_at": "2025-03-07T07:05:58.727118Z",
+						"name": "Påbörjar session för party id '5a6c3e4e-c320-4006-b448-1fd4121df828'",
+						"id": "158cfabe-1c3d-433c-b71f-1c909beaa291",
+						"messages": [
+							{
+								"created_at": "2025-03-07T07:05:58.727118Z",
+								"updated_at": "2025-03-14T16:30:10.682865Z",
+								"id": "834948e9-8eff-41ea-be48-9392617c918b",
+								"question": "Påbörjar session för party id '5a6c3e4e-c320-4006-b448-1fd4121df828'",
+								"answer": "Hej och välkommen! Hur kan jag hjälpa dig idag? \n\nHär är en översikt av dina anläggningar:\n\n| Anläggnings-ID | Adress                      | Typ av tjänst    |\n|----------------|-----------------------------|-------------------|\n| [facilityId]   | [careOf, street, postalCode, city] | [type]          |\n\nFyll gärna i med den specifika informationen så kan jag assistera dig vidare!",
+								"completion_model": {
+									"created_at": "2025-01-09T19:02:55.223252Z",
+									"updated_at": "2025-03-18T10:25:36.220323Z",
+									"id": "f2794da6-abe0-42c1-b1d8-351bc05a63e6",
+									"name": "gpt-4o-mini-azure",
+									"nickname": "GPT-4o mini (Azure)",
+									"family": "azure",
+									"token_limit": 128000,
+									"is_deprecated": false,
+									"stability": "stable",
+									"hosting": "swe",
+									"description": "Microsoft Azure's hosted version of the compact GPT-4 Omni model, offering faster processing with advanced capabilities.",
+									"deployment_name": "gpt-4o-mini",
+									"org": "Microsoft",
+									"vision": true,
+									"is_org_enabled": false,
+									"is_org_default": false
+								},
+								"references": [],
+								"files": [],
+								"tools": {
+									"assistants": [
+										{
+											"id": "1795219d-e4c5-43ab-a516-6dab4f07e479"
+										}
+									]
+								}
+							},
+							{
+								"created_at": "2025-03-07T07:49:50.405806Z",
+								"updated_at": "2025-03-14T16:30:10.682865Z",
+								"id": "b3784ef9-fa49-4e16-ad6e-bd6e7bbfdaa1",
+								"question": "What is the answer to the ultimate question of life, the universe and everything?",
+								"answer": "The answer to the ultimate question of life, the universe, and everything is famously known to be \"42.\" This concept comes from Douglas Adams' science fiction series \"The Hitchhiker's Guide to the Galaxy,\" where the randomness of the answer is part of the humor and satire of the narrative. \n\nIf you have any other questions or if there's anything else you'd like to discuss, feel free to let me know! I'm here to assist you with any inquiries regarding your energy services or other topics.",
+								"completion_model": {
+									"created_at": "2025-01-09T19:02:55.223252Z",
+									"updated_at": "2025-03-18T10:25:36.220323Z",
+									"id": "f2794da6-abe0-42c1-b1d8-351bc05a63e6",
+									"name": "gpt-4o-mini-azure",
+									"nickname": "GPT-4o mini (Azure)",
+									"family": "azure",
+									"token_limit": 128000,
+									"is_deprecated": false,
+									"stability": "stable",
+									"hosting": "swe",
+									"description": "Microsoft Azure's hosted version of the compact GPT-4 Omni model, offering faster processing with advanced capabilities.",
+									"deployment_name": "gpt-4o-mini",
+									"org": "Microsoft",
+									"vision": true,
+									"is_org_enabled": false,
+									"is_org_default": false
+								},
+								"references": [],
+								"files": [
+									{
+										"id": "578255c8-3fb9-4a3c-8ced-0f4a218c6e34",
+										"name": "selfservice-ai-data.json",
+										"size": 4026,
+										"created_at": "2025-03-07T07:06:04.579881Z",
+										"updated_at": "2025-03-07T07:06:04.579881Z"
+									}
+								],
+								"tools": {
+									"assistants": [
+										{
+											"id": "1795219d-e4c5-43ab-a516-6dab4f07e479"
+										}
+									]
+								}
+							}
+						]
+					},
+					"kundnummer": "11393",
+					"partyId": "9bb8472c-f528-4ed0-ba12-d5b6548d429e"
+				}
+			}
+		],
+		"urlPath": "/lime/chathistorik"
+	},
+	"response": {
+		"status": 204
+	},
+	"name": "api-lime-save-chathistory"
+}

--- a/src/integration-test/resources/AssistantIT/__files/test06_deleteSession/responses/api-intric-get-assistant-session-response.json
+++ b/src/integration-test/resources/AssistantIT/__files/test06_deleteSession/responses/api-intric-get-assistant-session-response.json
@@ -1,0 +1,97 @@
+{
+	"created_at": "2025-03-07T07:05:58.727118Z",
+	"updated_at": "2025-03-07T07:05:58.727118Z",
+	"name": "Påbörjar session för party id '5a6c3e4e-c320-4006-b448-1fd4121df828'",
+	"id": "158cfabe-1c3d-433c-b71f-1c909beaa291",
+	"messages": [
+		{
+			"created_at": "2025-03-07T07:05:58.727118Z",
+			"updated_at": "2025-03-14T16:30:10.682865Z",
+			"id": "834948e9-8eff-41ea-be48-9392617c918b",
+			"question": "Påbörjar session för party id '5a6c3e4e-c320-4006-b448-1fd4121df828'",
+			"answer": "Hej och välkommen! Hur kan jag hjälpa dig idag? \n\nHär är en översikt av dina anläggningar:\n\n| Anläggnings-ID | Adress                      | Typ av tjänst    |\n|----------------|-----------------------------|-------------------|\n| [facilityId]   | [careOf, street, postalCode, city] | [type]          |\n\nFyll gärna i med den specifika informationen så kan jag assistera dig vidare!",
+			"completion_model": {
+				"created_at": "2025-01-09T19:02:55.223252Z",
+				"updated_at": "2025-03-18T10:25:36.220323Z",
+				"id": "f2794da6-abe0-42c1-b1d8-351bc05a63e6",
+				"name": "gpt-4o-mini-azure",
+				"nickname": "GPT-4o mini (Azure)",
+				"family": "azure",
+				"token_limit": 128000,
+				"is_deprecated": false,
+				"nr_billion_parameters": null,
+				"hf_link": null,
+				"stability": "stable",
+				"hosting": "swe",
+				"open_source": null,
+				"description": "Microsoft Azure's hosted version of the compact GPT-4 Omni model, offering faster processing with advanced capabilities.",
+				"deployment_name": "gpt-4o-mini",
+				"org": "Microsoft",
+				"vision": true,
+				"reasoning": false,
+				"base_url": null,
+				"is_org_enabled": false,
+				"is_org_default": false
+			},
+			"references": [],
+			"files": [],
+			"tools": {
+				"assistants": [
+					{
+						"id": "1795219d-e4c5-43ab-a516-6dab4f07e479"
+					}
+				]
+			}
+		},
+		{
+			"created_at": "2025-03-07T07:49:50.405806Z",
+			"updated_at": "2025-03-14T16:30:10.682865Z",
+			"id": "b3784ef9-fa49-4e16-ad6e-bd6e7bbfdaa1",
+			"question": "What is the answer to the ultimate question of life, the universe and everything?",
+			"answer": "The answer to the ultimate question of life, the universe, and everything is famously known to be \"42.\" This concept comes from Douglas Adams' science fiction series \"The Hitchhiker's Guide to the Galaxy,\" where the randomness of the answer is part of the humor and satire of the narrative. \n\nIf you have any other questions or if there's anything else you'd like to discuss, feel free to let me know! I'm here to assist you with any inquiries regarding your energy services or other topics.",
+			"completion_model": {
+				"created_at": "2025-01-09T19:02:55.223252Z",
+				"updated_at": "2025-03-18T10:25:36.220323Z",
+				"id": "f2794da6-abe0-42c1-b1d8-351bc05a63e6",
+				"name": "gpt-4o-mini-azure",
+				"nickname": "GPT-4o mini (Azure)",
+				"family": "azure",
+				"token_limit": 128000,
+				"is_deprecated": false,
+				"nr_billion_parameters": null,
+				"hf_link": null,
+				"stability": "stable",
+				"hosting": "swe",
+				"open_source": null,
+				"description": "Microsoft Azure's hosted version of the compact GPT-4 Omni model, offering faster processing with advanced capabilities.",
+				"deployment_name": "gpt-4o-mini",
+				"org": "Microsoft",
+				"vision": true,
+				"reasoning": false,
+				"base_url": null,
+				"is_org_enabled": false,
+				"is_org_default": false
+			},
+			"references": [],
+			"files": [
+				{
+					"created_at": "2025-03-07T07:06:04.579881Z",
+					"updated_at": "2025-03-07T07:06:04.579881Z",
+					"id": "578255c8-3fb9-4a3c-8ced-0f4a218c6e34",
+					"name": "selfservice-ai-data.json",
+					"mimetype": "application/json",
+					"size": 4026,
+					"transcription": null
+				}
+			],
+			"tools": {
+				"assistants": [
+					{
+						"id": "1795219d-e4c5-43ab-a516-6dab4f07e479"
+					}
+				]
+			}
+		}
+	],
+	"feedback": null
+}

--- a/src/main/java/se/sundsvall/selfserviceai/api/AssistantResource.java
+++ b/src/main/java/se/sundsvall/selfserviceai/api/AssistantResource.java
@@ -65,7 +65,7 @@ class AssistantResource {
 		@RequestBody @Valid final SessionRequest request) {
 
 		// Create session
-		final var sessionId = assistantService.createSession(municipalityId);
+		final var sessionId = assistantService.createSession(municipalityId, request.getPartyId());
 
 		// Populate session with information (asynchronously)
 		assistantService.populateWithInformation(sessionId, request);

--- a/src/main/java/se/sundsvall/selfserviceai/api/AssistantResource.java
+++ b/src/main/java/se/sundsvall/selfserviceai/api/AssistantResource.java
@@ -34,6 +34,7 @@ import org.zalando.problem.Problem;
 import org.zalando.problem.violations.ConstraintViolationProblem;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 import se.sundsvall.dept44.common.validators.annotation.ValidUuid;
+import se.sundsvall.dept44.requestid.RequestId;
 import se.sundsvall.selfserviceai.api.model.QuestionResponse;
 import se.sundsvall.selfserviceai.api.model.SessionRequest;
 import se.sundsvall.selfserviceai.api.model.SessionResponse;
@@ -111,7 +112,7 @@ class AssistantResource {
 		@Parameter(name = "id", description = "Session id", example = "f5211067-b3c7-4394-b84a-aa3fa65507e3") @PathVariable("id") @ValidUuid final String sessionId) {
 
 		// Handle removal of session (asynchronously)
-		assistantService.deleteSessionById(municipalityId, UUID.fromString(sessionId));
+		assistantService.deleteSessionById(municipalityId, UUID.fromString(sessionId), UUID.fromString(RequestId.get()));
 
 		return status(NO_CONTENT).header(CONTENT_TYPE, ALL_VALUE).build();
 	}

--- a/src/main/java/se/sundsvall/selfserviceai/integration/db/DatabaseMapper.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/db/DatabaseMapper.java
@@ -7,9 +7,10 @@ import se.sundsvall.selfserviceai.integration.db.model.SessionEntity;
 public class DatabaseMapper {
 	private DatabaseMapper() {}
 
-	public static SessionEntity toSessionEntity(String municipalityId, final UUID sessionId) {
+	public static SessionEntity toSessionEntity(String municipalityId, final UUID sessionId, final String partyId) {
 		return SessionEntity.builder()
 			.withMunicipalityId(municipalityId)
+			.withPartyId(partyId)
 			.withSessionId(sessionId.toString())
 			.build();
 	}

--- a/src/main/java/se/sundsvall/selfserviceai/integration/db/model/SessionEntity.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/db/model/SessionEntity.java
@@ -38,6 +38,12 @@ public class SessionEntity {
 	@Column(name = "municipality_id", nullable = false)
 	private String municipalityId;
 
+	@Column(name = "party_id", nullable = false)
+	private String partyId;
+
+	@Column(name = "customer_nbr")
+	private String customerNbr;
+
 	@Column(name = "created")
 	@TimeZoneStorage(NORMALIZE)
 	private OffsetDateTime created;
@@ -50,8 +56,8 @@ public class SessionEntity {
 	@TimeZoneStorage(NORMALIZE)
 	private OffsetDateTime lastAccessed;
 
-	@Column(name = "initiation_status", columnDefinition = "mediumtext")
-	private String initiationStatus;
+	@Column(name = "status", columnDefinition = "mediumtext")
+	private String status;
 
 	@Builder.Default
 	@OneToMany

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/IntricIntegration.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/IntricIntegration.java
@@ -87,7 +87,7 @@ public class IntricIntegration {
 			LOG.debug("Session deleted");
 			return true;
 		} catch (final Exception e) {
-			LOG.warn("Exception when deleting assistant session", e);
+			LOG.error("Exception when deleting assistant session, manual purge might be needed", e);
 			return false;
 		}
 	}
@@ -118,7 +118,7 @@ public class IntricIntegration {
 			LOG.debug("File deleted");
 			return true;
 		} catch (final Exception e) {
-			LOG.warn("Exception when deleting file", e);
+			LOG.error("Exception when deleting file, manual purge might be needed", e);
 			return false;
 		}
 	}

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Assistant.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Assistant.java
@@ -5,9 +5,7 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder(setterPrefix = "with")
-public record AskResponse(
+public record Assistant(
 
-	@JsonProperty("session_id") UUID sessionId,
-	@JsonProperty("question") String question,
-	@JsonProperty("answer") String answer) {
+	@JsonProperty("id") UUID id) {
 }

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/CompletionModel.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/CompletionModel.java
@@ -1,0 +1,32 @@
+package se.sundsvall.selfserviceai.integration.intric.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder(setterPrefix = "with")
+public record CompletionModel(
+
+	@JsonProperty("id") UUID id,
+	@JsonProperty("name") String name,
+	@JsonProperty("nickname") String nickname,
+	@JsonProperty("family") String family,
+	@JsonProperty("token_limit") Integer tokenLimit,
+	@JsonProperty("is_deprecated") Boolean isDeprecated,
+	@JsonProperty("nr_billion_parameters") Integer nrBillionParameters,
+	@JsonProperty("hf_link") String hfLink,
+	@JsonProperty("stability") String stability,
+	@JsonProperty("hosting") String hosting,
+	@JsonProperty("open_source") Boolean openSource,
+	@JsonProperty("description") String description,
+	@JsonProperty("deployment_name") String deploymentName,
+	@JsonProperty("org") String org,
+	@JsonProperty("vision") boolean vision,
+	@JsonProperty("reasoning") boolean reasoning,
+	@JsonProperty("base_url") String baseUrl,
+	@JsonProperty("is_org_enabled") boolean isOrgEnabled,
+	@JsonProperty("is_org_default") boolean isOrgDefault,
+	@JsonProperty("created_at") OffsetDateTime createdAt,
+	@JsonProperty("updated_at") OffsetDateTime updatedAt) {
+}

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/FilePublic.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/FilePublic.java
@@ -8,10 +8,10 @@ import lombok.Builder;
 @Builder(setterPrefix = "with")
 public record FilePublic(
 
-	@JsonProperty UUID id,
-	@JsonProperty String name,
-	@JsonProperty String mimeType,
-	@JsonProperty Integer size,
-	@JsonProperty OffsetDateTime createdAt,
-	@JsonProperty OffsetDateTime updatedAt) {
+	@JsonProperty("id") UUID id,
+	@JsonProperty("name") String name,
+	@JsonProperty("mime_type") String mimeType,
+	@JsonProperty("size") Integer size,
+	@JsonProperty("created_at") OffsetDateTime createdAt,
+	@JsonProperty("updated_at") OffsetDateTime updatedAt) {
 }

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Metadata.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Metadata.java
@@ -5,9 +5,10 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder(setterPrefix = "with")
-public record AskResponse(
+public record Metadata(
 
-	@JsonProperty("session_id") UUID sessionId,
-	@JsonProperty("question") String question,
-	@JsonProperty("answer") String answer) {
+	@JsonProperty("embedding_model_id") UUID embeddingModelId,
+	@JsonProperty("url") String url,
+	@JsonProperty("title") String title,
+	@JsonProperty("size") int size) {
 }

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Reference.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Reference.java
@@ -2,20 +2,16 @@ package se.sundsvall.selfserviceai.integration.intric.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder(setterPrefix = "with")
-public record Message(
+public record Reference(
 
 	@JsonProperty("id") UUID id,
-	@JsonProperty("question") String question,
-	@JsonProperty("answer") String answer,
-	@JsonProperty("completion_model") CompletionModel completionModel,
-	@JsonProperty("references") List<Reference> references,
-	@JsonProperty("files") List<FilePublic> files,
-	@JsonProperty("tools") Tools tools,
+	@JsonProperty("metadata") Metadata metadata,
+	@JsonProperty("group_id") UUID groupId,
+	@JsonProperty("website_id") UUID websiteId,
 	@JsonProperty("created_at") OffsetDateTime createdAt,
 	@JsonProperty("updated_at") OffsetDateTime updatedAt) {
 }

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/SessionFeedback.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/SessionFeedback.java
@@ -1,0 +1,11 @@
+package se.sundsvall.selfserviceai.integration.intric.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder(setterPrefix = "with")
+public record SessionFeedback(
+
+	@JsonProperty("value") int value,
+	@JsonProperty("text") String text) {
+}

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/SessionPublic.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/SessionPublic.java
@@ -9,9 +9,10 @@ import lombok.Builder;
 @Builder(setterPrefix = "with")
 public record SessionPublic(
 
-	@JsonProperty UUID id,
-	@JsonProperty String name,
-	@JsonProperty List<Message> messages,
-	@JsonProperty OffsetDateTime createdAt,
-	@JsonProperty OffsetDateTime updatedAt) {
+	@JsonProperty("id") UUID id,
+	@JsonProperty("name") String name,
+	@JsonProperty("messages") List<Message> messages,
+	@JsonProperty("feedback") SessionFeedback feedback,
+	@JsonProperty("created_at") OffsetDateTime createdAt,
+	@JsonProperty("updated_at") OffsetDateTime updatedAt) {
 }

--- a/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Tools.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/intric/model/Tools.java
@@ -1,0 +1,11 @@
+package se.sundsvall.selfserviceai.integration.intric.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+
+@Builder(setterPrefix = "with")
+public record Tools(
+
+	@JsonProperty("assistants") List<Assistant> assistants) {
+}

--- a/src/main/java/se/sundsvall/selfserviceai/integration/lime/LimeIntegration.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/lime/LimeIntegration.java
@@ -19,8 +19,8 @@ public class LimeIntegration {
 		return limeClient.getChatHistory(sessionId);
 	}
 
-	public void saveChatHistory(String partyId, boolean isOrganization, int customerNbr, SessionPublic session) {
-		limeClient.saveChatHistory(toChatHistoryRequest(partyId, isOrganization, customerNbr, session));
+	public void saveChatHistory(String partyId, String customerNbr, SessionPublic session) {
+		limeClient.saveChatHistory(toChatHistoryRequest(partyId, customerNbr, session));
 	}
 
 }

--- a/src/main/java/se/sundsvall/selfserviceai/integration/lime/configuration/LimeConfiguration.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/lime/configuration/LimeConfiguration.java
@@ -1,5 +1,7 @@
 package se.sundsvall.selfserviceai.integration.lime.configuration;
 
+import static java.util.Optional.ofNullable;
+
 import feign.RequestInterceptor;
 import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -22,7 +24,7 @@ public class LimeConfiguration {
 			.composeCustomizersToOne();
 	}
 
-	RequestInterceptor requestInterceptor(final String apiKey) {
-		return requestTemplate -> requestTemplate.header(API_KEY_HEADER_NAME, apiKey);
+	RequestInterceptor requestInterceptor(final String secret) {
+		return requestTemplate -> ofNullable(secret).ifPresent(s -> requestTemplate.header(API_KEY_HEADER_NAME, s));
 	}
 }

--- a/src/main/java/se/sundsvall/selfserviceai/integration/lime/mapper/LimeMapper.java
+++ b/src/main/java/se/sundsvall/selfserviceai/integration/lime/mapper/LimeMapper.java
@@ -4,30 +4,34 @@ import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 
 import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto;
+import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto;
 import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto;
 import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest;
+import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import se.sundsvall.selfserviceai.integration.intric.model.CompletionModel;
 import se.sundsvall.selfserviceai.integration.intric.model.Message;
 import se.sundsvall.selfserviceai.integration.intric.model.SessionPublic;
+import se.sundsvall.selfserviceai.integration.intric.model.Tools;
 
 public class LimeMapper {
 	private LimeMapper() {}
 
-	public static ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest toChatHistoryRequest(String identity, boolean isOrganization, int customerNbr, SessionPublic session) {
+	public static ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest toChatHistoryRequest(String partyId, String customerNbr, SessionPublic session) {
 		return ofNullable(session)
 			.map(s -> new ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest()
 				.chatSession(toChatSessionDto(s))
-				.identitetsnummer(identity)
-				.isOrganisation(isOrganization)
-				.kundnummer(String.valueOf(customerNbr)))
+				.partyId(partyId)
+				.kundnummer(customerNbr))
 			.orElse(null);
 	}
 
 	private static ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto toChatSessionDto(SessionPublic session) {
 		return new ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto()
 			.createdAt(session.createdAt())
+			.feedback(session.feedback())
 			.id(ofNullable(session.id())
 				.map(UUID::toString)
 				.orElse(null))
@@ -45,15 +49,53 @@ public class LimeMapper {
 
 	private static ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto toMessageDto(Message message) {
 		return ofNullable(message)
-			.map(x -> new ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto()
-				.answer(message.answer())
-				.createdAt(message.createdAt())
-				.files(message.files())
-				.id(ofNullable(message.id())
+			.map(m -> new ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto()
+				.answer(m.answer())
+				.completionModel(toCompletionModelDto(m.completionModel()))
+				.createdAt(m.createdAt())
+				.files(m.files())
+				.id(ofNullable(m.id())
 					.map(UUID::toString)
 					.orElse(null))
-				.question(message.question())
-				.updatedAt(message.updatedAt()))
+				.references(m.references())
+				.tools(toToolsDto(m.tools()))
+				.question(m.question())
+				.updatedAt(m.updatedAt()))
 			.orElse(null);
 	}
+
+	private static ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto toCompletionModelDto(CompletionModel completionModel) {
+		return ofNullable(completionModel)
+			.map(c -> new ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto()
+				.createdAt(c.createdAt())
+				.deploymentName(c.deploymentName())
+				.description(c.description())
+				.family(c.family())
+				.hfLink(c.hfLink())
+				.hosting(c.hosting())
+				.id(ofNullable(c.id())
+					.map(UUID::toString)
+					.orElse(null))
+				.isDeprecated(c.isDeprecated())
+				.isOrgEnabled(c.isOrgEnabled())
+				.isOrgDefault(c.isOrgDefault())
+				.name(c.name())
+				.nickname(c.nickname())
+				.nrBillionParameters(c.nrBillionParameters())
+				.stability(c.stability())
+				.openSource(c.openSource())
+				.org(c.org())
+				.tokenLimit(c.tokenLimit())
+				.vision(c.vision())
+				.updatedAt(c.updatedAt()))
+			.orElse(null);
+	}
+
+	private static ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto toToolsDto(Tools tools) {
+		return ofNullable(tools)
+			.map(t -> new ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto()
+				.assistants(t.assistants()))
+			.orElse(null);
+	}
+
 }

--- a/src/main/java/se/sundsvall/selfserviceai/service/AssistantService.java
+++ b/src/main/java/se/sundsvall/selfserviceai/service/AssistantService.java
@@ -1,6 +1,7 @@
 package se.sundsvall.selfserviceai.service;
 
 import static java.util.Objects.isNull;
+import static java.util.Optional.ofNullable;
 import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
 import static org.zalando.problem.Status.NOT_FOUND;
 import static se.sundsvall.selfserviceai.integration.db.DatabaseMapper.toFileEntity;
@@ -140,7 +141,9 @@ public class AssistantService {
 
 	@Async
 	@Transactional
-	public void deleteSessionById(final String municipalityId, final UUID sessionId) {
+	public void deleteSessionById(final String municipalityId, final UUID sessionId, UUID requestId) {
+		RequestId.init(ofNullable(requestId).orElse(UUID.randomUUID()).toString());
+
 		sessionRepository.findBySessionIdAndMunicipalityId(sessionId.toString(), municipalityId)
 			.ifPresentOrElse(entity -> Stream.of(entity)
 				.map(this::saveChatHistory)

--- a/src/main/resources/contracts/lime/lime.yml
+++ b/src/main/resources/contracts/lime/lime.yml
@@ -1,198 +1,365 @@
----
-x-generator: NSwag v14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))
-openapi: 3.0.0
-info:
-  title: Servanet.ItOps.ApiGatewayAdapter
-  version: v1
-servers:
-- url: http://localhost:8080
-paths:
-  "/api/chathistorik/{sessionId}":
-    get:
-      tags:
-      - Chathistorik
-      summary: Hämta ett inlagg
-      description: Hämta ett inlagg med hjälp av ett sessionId
-      operationId: ApiEndpointsChathistorikHamtaChathistorikEndpoint
-      parameters:
-      - name: sessionId
-        in: path
-        required: true
-        description: Id på inlägget som ska hämtas
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Loggen som postats in.
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsResponsesChathistorikChathistorikResponse"
-  "/api/chathistorik":
-    post:
-      tags:
-      - Chathistorik
-      summary: Skapa en chathistorik
-      description: Skapa en ny chathistorik med meddelanden
-      operationId: ApiEndpointsChathistorikSkapaChathistorikEndpoint
-      requestBody:
-        x-name: SkapaChathistorikRequest
-        description: ''
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest"
-        required: true
-        x-position: 1
-      responses:
-        '204':
-          description: No Content
-        '400':
-          description: Bad Request
-          content:
-            application/problem+json:
-              schema:
-                "$ref": "#/components/schemas/FastEndpointsErrorResponse"
-components:
-  schemas:
-    ServanetItOpsApiGatewayAdapterHttpContractsModelsResponsesChathistorikChathistorikResponse:
-      type: object
-      additionalProperties: false
-      properties:
-        chatSession:
-          "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto"
-    ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto:
-      type: object
-      additionalProperties: false
-      properties:
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-        name:
-          type: string
-        id:
-          type: string
-          format: guid
-        messages:
-          type: array
-          items:
-            "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto"
-        feedback: {}
-    ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto:
-      type: object
-      additionalProperties: false
-      properties:
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-        id:
-          type: string
-        question:
-          type: string
-        answer:
-          type: string
-        completion_model:
-          "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto"
-        references: {}
-        files: {}
-        tools:
-          "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto"
-    ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto:
-      type: object
-      additionalProperties: false
-      properties:
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-        id:
-          type: string
-        name:
-          type: string
-        nickname:
-          type: string
-        family:
-          type: string
-        token_limit:
-          type: integer
-          format: int32
-        is_deprecated:
-          type: boolean
-        nr_billion_parameters: {}
-        hf_link: {}
-        stability:
-          type: string
-        hosting:
-          type: string
-        open_source: {}
-        description:
-          type: string
-        deployment_name:
-          type: string
-        org:
-          type: string
-        vision:
-          type: boolean
-        is_org_enabled:
-          type: boolean
-        is_org_default:
-          type: boolean
-    ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto:
-      type: object
-      additionalProperties: false
-      properties:
-        assistants: {}
-    FastEndpointsErrorResponse:
-      type: object
-      additionalProperties: false
-      properties:
-        statusCode:
-          type: integer
-          format: int32
-          default: 400
-        message:
-          type: string
-          default: One or more errors occurred!
-        errors:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-    ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest:
-      type: object
-      additionalProperties: false
-      required:
-      - chatSession
-      properties:
-        chatSession:
-          minLength: 1
-          nullable: false
-          "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto"
-        kundnummer:
-          type: string
-        identitetsnummer:
-          type: string
-        isOrganisation:
-          type: boolean
-  securitySchemes:
-    JWTBearerAuth:
-      type: http
-      description: Enter a JWT token to authorize the requests...
-      scheme: Bearer
-      bearerFormat: JWT
-    X-Client-Secret:
-      type: apiKey
-      description: Ange din X-Client-Secret i detta fält.
-      name: X-Client-Secret
-      in: header
-security:
-- X-Client-Secret: []
+{
+  "x-generator": "NSwag v14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))",
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Servanet.ItOps.ApiGatewayAdapter",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:5222"
+    }
+  ],
+  "paths": {
+    "/api/kund/{partyId}/synkronisera": {
+      "post": {
+        "tags": [
+          "Kund"
+        ],
+        "summary": "Synkroniserar en kund",
+        "description": "Skapar ett synkroniseringsjobb för en kund",
+        "operationId": "ApiEndpointsKundSynkroniseraSynkroniseraKundEndpoint",
+        "parameters": [
+          {
+            "name": "partyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/api/kund/synkronisera": {
+      "post": {
+        "tags": [
+          "Kund"
+        ],
+        "summary": "Synkroniserar kunder",
+        "description": "Skapar ett synkroniseringsjobb för kunder",
+        "operationId": "ApiEndpointsKundSynkroniseraSynkroniseraKunderEndpoint",
+        "requestBody": {
+          "x-name": "SynkroniseraKunderRequest",
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsKundSynkroniseraKunderRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/api/chathistorik/{sessionId}": {
+      "get": {
+        "tags": [
+          "Chathistorik"
+        ],
+        "summary": "Hämta ett inlagg",
+        "description": "Hämta ett inlagg med hjälp av ett sessionId",
+        "operationId": "ApiEndpointsChathistorikHamtaChathistorikEndpoint",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "description": "Id på inlägget som ska hämtas",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Loggen som postats in.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsResponsesChathistorikChathistorikResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chathistorik": {
+      "post": {
+        "tags": [
+          "Chathistorik"
+        ],
+        "summary": "Skapa en chathistorik",
+        "description": "Skapa en ny chathistorik med meddelanden",
+        "operationId": "ApiEndpointsChathistorikSkapaChathistorikEndpoint",
+        "requestBody": {
+          "x-name": "SkapaChathistorikRequest",
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsKundSynkroniseraKunderRequest": {
+        "type": "object",
+        "example": {
+          "sinceLatestSyncTimestamp": "2025-03-19T09:51:41.091218+01:00",
+          "startPage": 1,
+          "jobbId": "8dda672f-2641-462d-a4f3-18b26365fdf2"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "sinceLatestSyncTimestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "startPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "jobbId": {
+            "type": "string",
+            "format": "guid"
+          }
+        }
+      },
+      "ServanetItOpsApiGatewayAdapterHttpContractsModelsResponsesChathistorikChathistorikResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "chatSession": {
+            "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto"
+          }
+        }
+      },
+      "ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "guid"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto"
+            }
+          },
+          "feedback": {}
+        }
+      },
+      "ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "answer": {
+            "type": "string"
+          },
+          "completion_model": {
+            "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto"
+          },
+          "references": {},
+          "files": {},
+          "tools": {
+            "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto"
+          }
+        }
+      },
+      "ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nickname": {
+            "type": "string"
+          },
+          "family": {
+            "type": "string"
+          },
+          "token_limit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "is_deprecated": {
+            "type": "boolean"
+          },
+          "nr_billion_parameters": {},
+          "hf_link": {},
+          "stability": {
+            "type": "string"
+          },
+          "hosting": {
+            "type": "string"
+          },
+          "open_source": {},
+          "description": {
+            "type": "string"
+          },
+          "deployment_name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "vision": {
+            "type": "boolean"
+          },
+          "is_org_enabled": {
+            "type": "boolean"
+          },
+          "is_org_default": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "assistants": {}
+        }
+      },
+      "FastEndpointsErrorResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "statusCode": {
+            "type": "integer",
+            "format": "int32",
+            "default": 400
+          },
+          "message": {
+            "type": "string",
+            "default": "One or more errors occurred!"
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "chatSession"
+        ],
+        "properties": {
+          "chatSession": {
+            "minLength": 1,
+            "nullable": false,
+            "$ref": "#/components/schemas/ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto"
+          },
+          "kundnummer": {
+            "type": "string"
+          },
+          "partyId": {
+            "type": "string",
+            "format": "guid"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "JWTBearerAuth": {
+        "type": "http",
+        "description": "Enter a JWT token to authorize the requests...",
+        "scheme": "Bearer",
+        "bearerFormat": "JWT"
+      },
+      "X-Client-Secret": {
+        "type": "apiKey",
+        "description": "Ange din X-Client-Secret i detta fält.",
+        "name": "X-Client-Secret",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "X-Client-Secret": []
+    }
+  ]
+}

--- a/src/main/resources/db/migration/V1_0__add_database_schema.sql
+++ b/src/main/resources/db/migration/V1_0__add_database_schema.sql
@@ -22,9 +22,11 @@
         created datetime(6),
         initialized datetime(6),
         last_accessed datetime(6),
-        initiation_status mediumtext,
+        customer_nbr varchar(255),
         municipality_id varchar(255) not null,
+        party_id varchar(255) not null,
         session_id varchar(255) not null,
+        status mediumtext,
         primary key (session_id)
     ) engine=InnoDB;
 

--- a/src/test/java/se/sundsvall/selfserviceai/TestFactory.java
+++ b/src/test/java/se/sundsvall/selfserviceai/TestFactory.java
@@ -18,15 +18,25 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
+import se.sundsvall.selfserviceai.integration.intric.model.Assistant;
+import se.sundsvall.selfserviceai.integration.intric.model.CompletionModel;
+import se.sundsvall.selfserviceai.integration.intric.model.FilePublic;
+import se.sundsvall.selfserviceai.integration.intric.model.Message;
+import se.sundsvall.selfserviceai.integration.intric.model.Metadata;
+import se.sundsvall.selfserviceai.integration.intric.model.Reference;
+import se.sundsvall.selfserviceai.integration.intric.model.SessionFeedback;
+import se.sundsvall.selfserviceai.integration.intric.model.SessionPublic;
+import se.sundsvall.selfserviceai.integration.intric.model.Tools;
 
 public class TestFactory {
 	private TestFactory() {}
 
-	private static final String NO_MATCH = "NO_MATCH";
+	// Installedbase/Agreement/Measurement/Invoices test-object constants
 
+	private static final String NO_MATCH = "NO_MATCH";
 	public static final String CUSTOMER_NUMBER = "123";
 	public static final String PARTY_ID = "8e46e6be-eaaf-40dd-b5c5-be3dbe858999";
-
 	public static final String IB1_FACILITY_ID = "facilityId1";
 	public static final int IB1_PLACEMENT_ID = 111;
 	public static final String IB1_TYPE = "type1";
@@ -102,7 +112,6 @@ public class TestFactory {
 	public static final String IB1_INVOICE2_TOTAL_AMOUNT = "2999.51";
 	public static final String IB1_INVOICE2_VAT = "0.25";
 	public static final String IB1_INVOICE2_VAT_ELIGIBLE_AMOUNT = "123.65";
-
 	public static final String IB2_FACILITY_ID = "facilityId2";
 	public static final int IB2_PLACEMENT_ID = 222;
 	public static final String IB2_TYPE = "type2";
@@ -126,6 +135,154 @@ public class TestFactory {
 	public static final String IB2_AGREEMENT1_MEASUREMENT1_UNIT = "unit3";
 	public static final OffsetDateTime IB2_AGREEMENT1_MEASUREMENT1_TIMESTAMP = LocalDate.of(2024, 6, 15).atStartOfDay().minusHours(1).atZone(ZoneId.systemDefault()).toOffsetDateTime();
 	public static final BigDecimal IB2_AGREEMENT1_MEASUREMENT1_VALUE = new BigDecimal("500");
+
+	// Intric test-object constants
+
+	public static final UUID SESSION_ID = UUID.randomUUID();
+	public static final OffsetDateTime SESSION_CREATED = OffsetDateTime.now().minusHours(12);
+	public static final OffsetDateTime SESSION_UPDATED = OffsetDateTime.now().minusHours(11);
+	public static final String SESSION_NAME = "sessionName";
+	public static final UUID MESSAGE_ID = UUID.randomUUID();
+	public static final OffsetDateTime MESSAGE_CREATED = OffsetDateTime.now().minusHours(10);
+	public static final OffsetDateTime MESSAGE_UPDATED = OffsetDateTime.now().minusHours(9);
+	public static final UUID FILE_ID = UUID.randomUUID();
+	public static final OffsetDateTime FILE_CREATED = OffsetDateTime.now().minusHours(8);
+	public static final OffsetDateTime FILE_UPDATED = OffsetDateTime.now().minusHours(7);
+	public static final String FILE_MIME_TYPE = "mimeType";
+	public static final String FILE_NAME = "name";
+	public static final int FILE_SIZE = 123;
+	public static final String ANSWER = "answer";
+	public static final String QUESTION = "question";
+	public static final String TEXT = "text";
+	public static final int VALUE = 456;
+	public static final UUID ASSISTANT_ID = UUID.randomUUID();
+	public static final UUID REFERENCE_ID = UUID.randomUUID();
+	public static final UUID GROUP_ID = UUID.randomUUID();
+	public static final OffsetDateTime REFERENCE_CREATED = OffsetDateTime.now().minusHours(14);
+	public static final OffsetDateTime REFERENCE_UPDATED = OffsetDateTime.now().minusHours(13);
+	public static final UUID WEBSITE_ID = UUID.randomUUID();
+	public static final UUID EMBEDDING_MODEL_ID = UUID.randomUUID();
+	public static final int METADATA_SIZE = 789;
+	public static final String METADATA_TITLE = "metadataTitle";
+	public static final String METADATA_URL = "metadataUrl";
+	public static final String BASE_URL = "baseUrl";
+	public static final OffsetDateTime COMPLETION_MODEL_CREATED = OffsetDateTime.now().minusHours(14);
+	public static final OffsetDateTime COMPLETION_MODEL_UPDATED = OffsetDateTime.now().minusHours(13);
+	public static final UUID COMPLETION_MODEL_ID = UUID.randomUUID();
+	public static final String DEPLOYMENT_NAME = "deploymentName";
+	public static final String DESCRIPTION = "description";
+	public static final String FAMILY = "family";
+	public static final String HF_LINK = "hfLink";
+	public static final String HOSTING = "hosting";
+	public static final Boolean DEPRECATED = true;
+	public static final boolean ORG_DEFAULT = true;
+	public static final boolean ORG_ENABLED = true;
+	public static final String NAME = "name";
+	public static final String NICKNAME = "nickname";
+	public static final Integer NR_BILLION_PARAMETERS = 33;
+	public static final Boolean OPEN_SOURCE = true;
+	public static final String ORG = "org";
+	public static final boolean REASONING = true;
+	public static final String STABILITY = "stability";
+	public static final Integer TOKEN_LIMIT = 686;
+	public static final boolean VISION = true;
+
+	public static SessionPublic createSession() {
+		return SessionPublic.builder()
+			.withCreatedAt(SESSION_CREATED)
+			.withFeedback(createSessionFeedback())
+			.withId(SESSION_ID)
+			.withMessages(List.of(Message.builder()
+				.withAnswer(ANSWER)
+				.withCompletionModel(createCompletionModel())
+				.withCreatedAt(MESSAGE_CREATED)
+				.withFiles(List.of(createFilePublic()))
+				.withId(MESSAGE_ID)
+				.withQuestion(QUESTION)
+				.withReferences(List.of(createReference()))
+				.withTools(createTools())
+				.withUpdatedAt(MESSAGE_UPDATED)
+				.build()))
+			.withName(SESSION_NAME)
+			.withUpdatedAt(SESSION_UPDATED)
+			.build();
+	}
+
+	private static Tools createTools() {
+		return Tools.builder()
+			.withAssistants(List.of(createAssistant()))
+			.build();
+	}
+
+	public static Assistant createAssistant() {
+		return Assistant.builder()
+			.withId(ASSISTANT_ID)
+			.build();
+	}
+
+	public static Reference createReference() {
+		return Reference.builder()
+			.withCreatedAt(REFERENCE_CREATED)
+			.withGroupId(GROUP_ID)
+			.withId(REFERENCE_ID)
+			.withMetadata(createMetadata())
+			.withUpdatedAt(REFERENCE_UPDATED)
+			.withWebsiteId(WEBSITE_ID)
+			.build();
+	}
+
+	private static Metadata createMetadata() {
+		return Metadata.builder()
+			.withEmbeddingModelId(EMBEDDING_MODEL_ID)
+			.withSize(METADATA_SIZE)
+			.withTitle(METADATA_TITLE)
+			.withUrl(METADATA_URL)
+			.build();
+	}
+
+	private static CompletionModel createCompletionModel() {
+		return CompletionModel.builder()
+			.withBaseUrl(BASE_URL)
+			.withCreatedAt(COMPLETION_MODEL_CREATED)
+			.withDeploymentName(DEPLOYMENT_NAME)
+			.withDescription(DESCRIPTION)
+			.withFamily(FAMILY)
+			.withHfLink(HF_LINK)
+			.withHosting(HOSTING)
+			.withId(COMPLETION_MODEL_ID)
+			.withIsDeprecated(DEPRECATED)
+			.withIsOrgDefault(ORG_DEFAULT)
+			.withIsOrgEnabled(ORG_ENABLED)
+			.withName(NAME)
+			.withNickname(NICKNAME)
+			.withNrBillionParameters(NR_BILLION_PARAMETERS)
+			.withOpenSource(OPEN_SOURCE)
+			.withOrg(ORG)
+			.withReasoning(REASONING)
+			.withStability(STABILITY)
+			.withTokenLimit(TOKEN_LIMIT)
+			.withUpdatedAt(COMPLETION_MODEL_UPDATED)
+			.withVision(VISION)
+			.build();
+	}
+
+	public static SessionFeedback createSessionFeedback() {
+		return SessionFeedback.builder()
+			.withText(TEXT)
+			.withValue(VALUE)
+			.build();
+	}
+
+	public static FilePublic createFilePublic() {
+		return FilePublic.builder()
+			.withCreatedAt(FILE_CREATED)
+			.withId(FILE_ID)
+			.withMimeType(FILE_MIME_TYPE)
+			.withName(FILE_NAME)
+			.withSize(FILE_SIZE)
+			.withUpdatedAt(FILE_UPDATED)
+			.build();
+	}
 
 	public static InstalledBaseCustomer createCustomer() {
 		return new InstalledBaseCustomer()

--- a/src/test/java/se/sundsvall/selfserviceai/api/SessionResourceTest.java
+++ b/src/test/java/se/sundsvall/selfserviceai/api/SessionResourceTest.java
@@ -1,6 +1,8 @@
 package se.sundsvall.selfserviceai.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -159,6 +161,6 @@ class SessionResourceTest {
 			.expectBody().isEmpty();
 
 		// Assert and verify
-		verify(mockService).deleteSessionById(MUNICIPALITY_ID, sessionId);
+		verify(mockService).deleteSessionById(eq(MUNICIPALITY_ID), eq(sessionId), any(UUID.class));
 	}
 }

--- a/src/test/java/se/sundsvall/selfserviceai/api/SessionResourceTest.java
+++ b/src/test/java/se/sundsvall/selfserviceai/api/SessionResourceTest.java
@@ -53,7 +53,7 @@ class SessionResourceTest {
 			.withPartyId(partyId)
 			.build();
 
-		when(mockService.createSession(MUNICIPALITY_ID)).thenReturn(sessionId);
+		when(mockService.createSession(MUNICIPALITY_ID, partyId)).thenReturn(sessionId);
 
 		// Act
 		final var response = webTestClient.post()
@@ -68,7 +68,7 @@ class SessionResourceTest {
 
 		// Assert and verify
 		assertThat(response).isNotNull().extracting(SessionResponse::getSessionId).isEqualTo(sessionId.toString());
-		verify(mockService).createSession(MUNICIPALITY_ID);
+		verify(mockService).createSession(MUNICIPALITY_ID, partyId);
 		verify(mockService).populateWithInformation(sessionId, body);
 	}
 

--- a/src/test/java/se/sundsvall/selfserviceai/integration/db/SessionRepositoryTest.java
+++ b/src/test/java/se/sundsvall/selfserviceai/integration/db/SessionRepositoryTest.java
@@ -43,6 +43,7 @@ class SessionRepositoryTest {
 		final var session = SessionEntity.builder()
 			.withMunicipalityId(MUNICIPALITY)
 			.withSessionId(sessionId)
+			.withPartyId(UUID.randomUUID().toString())
 			.build();
 
 		assertThat(sessionRepository.existsById(sessionId)).isFalse();
@@ -74,7 +75,9 @@ class SessionRepositoryTest {
 
 		assertThat(session.getCreated()).isEqualTo(OffsetDateTime.of(LocalDateTime.of(2025, 1, 1, 11, 0, 0), OffsetDateTime.now(systemDefault()).getOffset()));
 		assertThat(session.getInitialized()).isEqualTo(OffsetDateTime.of(LocalDateTime.of(2025, 1, 1, 11, 0, 30), OffsetDateTime.now(systemDefault()).getOffset()));
-		assertThat(session.getInitiationStatus()).isEqualTo("Successfully initialized");
+		assertThat(session.getStatus()).isEqualTo("Successfully initialized");
+		assertThat(session.getPartyId()).isEqualTo("e7d536c8-86a7-4a65-98ce-e700e65e31d7");
+		assertThat(session.getCustomerNbr()).isEqualTo("16324");
 		assertThat(session.getLastAccessed()).isNull();
 		assertThat(session.getMunicipalityId()).isEqualTo(MUNICIPALITY);
 		assertThat(session.getFiles()).hasSize(2)
@@ -134,11 +137,11 @@ class SessionRepositoryTest {
 		final var file = fileRepository.save(FileEntity.builder().withFileId(UUID.randomUUID().toString()).build());
 
 		assertThat(session.getInitialized()).isNull();
-		assertThat(session.getInitiationStatus()).isNull();
+		assertThat(session.getStatus()).isNull();
 		assertThat(session.getFiles()).isEmpty();
 
 		session.setInitialized(OffsetDateTime.now());
-		session.setInitiationStatus("Successfully initialized");
+		session.setStatus("Successfully initialized");
 		session.getFiles().add(file);
 
 		sessionRepository.save(session);

--- a/src/test/java/se/sundsvall/selfserviceai/integration/db/model/SessionEntityTest.java
+++ b/src/test/java/se/sundsvall/selfserviceai/integration/db/model/SessionEntityTest.java
@@ -39,31 +39,37 @@ class SessionEntityTest {
 	@Test
 	void testBuilderMethods() {
 		final var created = OffsetDateTime.now().minusHours(1);
+		final var customerNbr = "customerNbr";
 		final var files = List.of(FileEntity.builder().build());
 		final var initialized = OffsetDateTime.now().minusMinutes(59);
-		final var initiationStatus = "initiationStatus";
 		final var lastAccessed = OffsetDateTime.now().minusMinutes(55);
 		final var municipalityId = "municipalityId";
+		final var partyId = "partyId";
 		final var sessionId = "sessionId";
+		final var status = "status";
 
 		final var bean = SessionEntity.builder()
 			.withCreated(created)
+			.withCustomerNbr(customerNbr)
 			.withFiles(files)
 			.withInitialized(initialized)
-			.withInitiationStatus(initiationStatus)
 			.withLastAccessed(lastAccessed)
 			.withMunicipalityId(municipalityId)
+			.withPartyId(partyId)
 			.withSessionId(sessionId)
+			.withStatus(status)
 			.build();
 
 		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(bean.getCreated()).isEqualTo(created);
+		assertThat(bean.getCustomerNbr()).isEqualTo(customerNbr);
 		assertThat(bean.getFiles()).isEqualTo(files);
 		assertThat(bean.getInitialized()).isEqualTo(initialized);
-		assertThat(bean.getInitiationStatus()).isEqualTo(initiationStatus);
 		assertThat(bean.getLastAccessed()).isEqualTo(lastAccessed);
 		assertThat(bean.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(bean.getPartyId()).isEqualTo(partyId);
 		assertThat(bean.getSessionId()).isEqualTo(sessionId);
+		assertThat(bean.getStatus()).isEqualTo(status);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/selfserviceai/integration/lime/LimeIntegrationTest.java
+++ b/src/test/java/se/sundsvall/selfserviceai/integration/lime/LimeIntegrationTest.java
@@ -26,8 +26,7 @@ import se.sundsvall.selfserviceai.integration.intric.model.SessionPublic;
 class LimeIntegrationTest {
 
 	private static final String PARTY_ID = "partyId";
-	private static final boolean IS_ORGANIZATION = true;
-	private static final int CUSTOMER_NUMBER = 121212;
+	private static final String CUSTOMER_NUMBER = "121212";
 	private static final String SESSION_ID = "sessionId";
 
 	@Mock
@@ -51,7 +50,7 @@ class LimeIntegrationTest {
 	void saveHistory() {
 
 		// Arrange and act
-		integration.saveChatHistory(PARTY_ID, IS_ORGANIZATION, CUSTOMER_NUMBER, SessionPublic.builder().build());
+		integration.saveChatHistory(PARTY_ID, CUSTOMER_NUMBER, SessionPublic.builder().build());
 
 		// Assert and verify
 		verify(clientMock).saveChatHistory(any(ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest.class));
@@ -67,7 +66,7 @@ class LimeIntegrationTest {
 			.thenThrow(Problem.valueOf(Status.I_AM_A_TEAPOT, "Big and stout"));
 
 		// Act
-		final var e = assertThrows(ThrowableProblem.class, () -> integration.saveChatHistory(PARTY_ID, IS_ORGANIZATION, CUSTOMER_NUMBER, session));
+		final var e = assertThrows(ThrowableProblem.class, () -> integration.saveChatHistory(PARTY_ID, CUSTOMER_NUMBER, session));
 
 		// Assert and verify
 		verify(clientMock).saveChatHistory(any(ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest.class));

--- a/src/test/java/se/sundsvall/selfserviceai/integration/lime/mapper/LimeMapperTest.java
+++ b/src/test/java/se/sundsvall/selfserviceai/integration/lime/mapper/LimeMapperTest.java
@@ -1,15 +1,48 @@
 package se.sundsvall.selfserviceai.integration.lime.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+import static se.sundsvall.selfserviceai.TestFactory.ANSWER;
+import static se.sundsvall.selfserviceai.TestFactory.COMPLETION_MODEL_CREATED;
+import static se.sundsvall.selfserviceai.TestFactory.COMPLETION_MODEL_ID;
+import static se.sundsvall.selfserviceai.TestFactory.COMPLETION_MODEL_UPDATED;
+import static se.sundsvall.selfserviceai.TestFactory.DEPLOYMENT_NAME;
+import static se.sundsvall.selfserviceai.TestFactory.DEPRECATED;
+import static se.sundsvall.selfserviceai.TestFactory.DESCRIPTION;
+import static se.sundsvall.selfserviceai.TestFactory.FAMILY;
+import static se.sundsvall.selfserviceai.TestFactory.HF_LINK;
+import static se.sundsvall.selfserviceai.TestFactory.HOSTING;
+import static se.sundsvall.selfserviceai.TestFactory.MESSAGE_CREATED;
+import static se.sundsvall.selfserviceai.TestFactory.MESSAGE_ID;
+import static se.sundsvall.selfserviceai.TestFactory.MESSAGE_UPDATED;
+import static se.sundsvall.selfserviceai.TestFactory.NAME;
+import static se.sundsvall.selfserviceai.TestFactory.NICKNAME;
+import static se.sundsvall.selfserviceai.TestFactory.NR_BILLION_PARAMETERS;
+import static se.sundsvall.selfserviceai.TestFactory.OPEN_SOURCE;
+import static se.sundsvall.selfserviceai.TestFactory.ORG;
+import static se.sundsvall.selfserviceai.TestFactory.ORG_DEFAULT;
+import static se.sundsvall.selfserviceai.TestFactory.ORG_ENABLED;
+import static se.sundsvall.selfserviceai.TestFactory.PARTY_ID;
+import static se.sundsvall.selfserviceai.TestFactory.QUESTION;
+import static se.sundsvall.selfserviceai.TestFactory.SESSION_CREATED;
+import static se.sundsvall.selfserviceai.TestFactory.SESSION_ID;
+import static se.sundsvall.selfserviceai.TestFactory.SESSION_NAME;
+import static se.sundsvall.selfserviceai.TestFactory.SESSION_UPDATED;
+import static se.sundsvall.selfserviceai.TestFactory.STABILITY;
+import static se.sundsvall.selfserviceai.TestFactory.TOKEN_LIMIT;
+import static se.sundsvall.selfserviceai.TestFactory.VISION;
 
 import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto;
+import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto;
+import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto;
 import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest;
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.UUID;
+import generated.se.sundsvall.lime.ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto;
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.Test;
+import se.sundsvall.selfserviceai.TestFactory;
+import se.sundsvall.selfserviceai.integration.intric.model.Assistant;
 import se.sundsvall.selfserviceai.integration.intric.model.FilePublic;
-import se.sundsvall.selfserviceai.integration.intric.model.Message;
+import se.sundsvall.selfserviceai.integration.intric.model.Reference;
 import se.sundsvall.selfserviceai.integration.intric.model.SessionPublic;
 
 class LimeMapperTest {
@@ -18,87 +51,99 @@ class LimeMapperTest {
 	void fromFullSession() {
 
 		// Arrange
-		final var identity = "identity";
-		final var isOrganization = true;
-		final var customerNbr = 123456;
-		final var sessionId = UUID.randomUUID();
-		final var sessionCreated = OffsetDateTime.now().minusHours(12);
-		final var sessionUpdated = OffsetDateTime.now().minusHours(11);
-		final var sessionName = "sessionName";
-		final var messageId = UUID.randomUUID();
-		final var messageCreated = OffsetDateTime.now().minusHours(10);
-		final var messageUpdated = OffsetDateTime.now().minusHours(9);
-		final var fileId = UUID.randomUUID();
-		final var fileCreated = OffsetDateTime.now().minusHours(8);
-		final var fileUpdated = OffsetDateTime.now().minusHours(7);
-		final var fileMimeType = "mimeType";
-		final var fileName = "name";
-		final var fileSize = 123;
-		final var answer = "answer";
-		final var question = "question";
-		final var file = FilePublic.builder()
-			.withCreatedAt(fileCreated)
-			.withId(fileId)
-			.withMimeType(fileMimeType)
-			.withName(fileName)
-			.withSize(fileSize)
-			.withUpdatedAt(fileUpdated)
-			.build();
-		final var session = SessionPublic.builder()
-			.withCreatedAt(sessionCreated)
-			.withId(sessionId)
-			.withMessages(List.of(Message.builder()
-				.withAnswer(answer)
-				.withCreatedAt(messageCreated)
-				.withFiles(List.of(file))
-				.withId(messageId)
-				.withQuestion(question)
-				.withUpdatedAt(messageUpdated)
-				.build()))
-			.withName(sessionName)
-			.withUpdatedAt(sessionUpdated)
-			.build();
+		final var customerNbr = "123456";
+		final var session = TestFactory.createSession();
 
 		// Act
-		final var bean = LimeMapper.toChatHistoryRequest(identity, isOrganization, customerNbr, session);
+		final var bean = LimeMapper.toChatHistoryRequest(PARTY_ID, customerNbr, session);
 
 		// Assert
 		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
-		assertThat(bean.getIdentitetsnummer()).isEqualTo(identity);
-		assertThat(bean.getIsOrganisation()).isEqualTo(isOrganization);
+		assertThat(bean.getPartyId()).isEqualTo(PARTY_ID);
 		assertThat(bean.getKundnummer()).isEqualTo(String.valueOf(customerNbr));
-		assertThat(bean.getChatSession()).satisfies(s -> {
-			assertThat(s.getCreatedAt()).isEqualTo(sessionCreated);
-			assertThat(s.getFeedback()).isNull();
-			assertThat(s.getId()).isEqualTo(sessionId.toString());
-			assertThat(s.getName()).isEqualTo(sessionName);
-			assertThat(s.getUpdatedAt()).isEqualTo(sessionUpdated);
-			assertThat(s.getMessages()).satisfiesExactly(m -> {
-				assertThat(m.getAnswer()).isEqualTo(answer);
-				assertThat(m.getCompletionModel()).isNull();
-				assertThat(m.getCreatedAt()).isEqualTo(messageCreated);
-				assertThat(m.getId()).isEqualTo(messageId.toString());
-				assertThat(m.getQuestion()).isEqualTo(question);
-				assertThat(m.getReferences()).isNull();
-				assertThat(m.getTools()).isNull();
-				assertThat(m.getUpdatedAt()).isEqualTo(messageUpdated);
-				assertThat(m.getFiles()).isNotNull();
-				assertThat(((List<?>) m.getFiles())).hasSize(1).satisfiesExactly(entry -> {
-					assertThat(entry).isSameAs(file);
-				});
-			});
-		});
+		assertThat(bean.getChatSession()).satisfies(this::assertChatSession);
+
+	}
+
+	private void assertChatSession(@NotNull ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto s) {
+		assertThat(s.getCreatedAt()).isEqualTo(SESSION_CREATED);
+		assertThat(s.getFeedback()).isNotNull().satisfies(this::assertFeedback);
+		assertThat(s.getId()).isEqualTo(SESSION_ID.toString());
+		assertThat(s.getName()).isEqualTo(SESSION_NAME);
+		assertThat(s.getUpdatedAt()).isEqualTo(SESSION_UPDATED);
+		assertThat(s.getMessages()).hasSize(1).satisfiesExactly(this::assertMessages);
+	}
+
+	private void assertFeedback(Object f) {
+		assertThat(f).usingRecursiveComparison().isEqualTo(TestFactory.createSessionFeedback());
+	}
+
+	private void assertMessages(ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikMessageDto m) {
+		assertThat(m.getAnswer()).isEqualTo(ANSWER);
+		assertThat(m.getCompletionModel()).isNotNull().satisfies(this::assertCompletionModel);
+		assertThat(m.getCreatedAt()).isEqualTo(MESSAGE_CREATED);
+		assertThat(m.getId()).isEqualTo(MESSAGE_ID.toString());
+		assertThat(m.getQuestion()).isEqualTo(QUESTION);
+		assertThat(m.getReferences()).isNotNull().asInstanceOf(LIST).hasSize(1).satisfiesExactly(this::assertReference);
+		assertThat(m.getTools()).isNotNull().satisfies(this::assertTools);
+		assertThat(m.getUpdatedAt()).isEqualTo(MESSAGE_UPDATED);
+		assertThat(m.getFiles()).isNotNull().asInstanceOf(LIST).hasSize(1).satisfiesExactly(this::assertFile);
+	}
+
+	private void assertFile(Object f) {
+		assertThat(f)
+			.isInstanceOf(FilePublic.class)
+			.usingRecursiveAssertion()
+			.isEqualTo(TestFactory.createFilePublic());
+	}
+
+	private void assertCompletionModel(ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikCompletionModelDto c) {
+		assertThat(c.getCreatedAt()).isEqualTo(COMPLETION_MODEL_CREATED);
+		assertThat(c.getDeploymentName()).isEqualTo(DEPLOYMENT_NAME);
+		assertThat(c.getDescription()).isEqualTo(DESCRIPTION);
+		assertThat(c.getFamily()).isEqualTo(FAMILY);
+		assertThat(c.getHfLink()).isEqualTo(HF_LINK);
+		assertThat(c.getHosting()).isEqualTo(HOSTING);
+		assertThat(c.getId()).isEqualTo(COMPLETION_MODEL_ID.toString());
+		assertThat(c.getIsDeprecated()).isEqualTo(DEPRECATED);
+		assertThat(c.getIsOrgDefault()).isEqualTo(ORG_DEFAULT);
+		assertThat(c.getIsOrgEnabled()).isEqualTo(ORG_ENABLED);
+		assertThat(c.getName()).isEqualTo(NAME);
+		assertThat(c.getNickname()).isEqualTo(NICKNAME);
+		assertThat(c.getNrBillionParameters()).isEqualTo(NR_BILLION_PARAMETERS);
+		assertThat(c.getOpenSource()).isEqualTo(OPEN_SOURCE);
+		assertThat(c.getOrg()).isEqualTo(ORG);
+		assertThat(c.getStability()).isEqualTo(STABILITY);
+		assertThat(c.getTokenLimit()).isEqualTo(TOKEN_LIMIT);
+		assertThat(c.getUpdatedAt()).isEqualTo(COMPLETION_MODEL_UPDATED);
+		assertThat(c.getVision()).isEqualTo(VISION);
+	}
+
+	private void assertTools(ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikToolsDto t) {
+		assertThat(t.getAssistants())
+			.isNotNull()
+			.asInstanceOf(LIST).hasSize(1).satisfiesExactly(this::assertAssistant);
+	}
+
+	private void assertAssistant(Object a) {
+		assertThat(a)
+			.isInstanceOf(Assistant.class)
+			.usingRecursiveAssertion()
+			.isEqualTo(TestFactory.createAssistant());
+	}
+
+	private void assertReference(Object r) {
+		assertThat(r)
+			.isInstanceOf(Reference.class)
+			.usingRecursiveAssertion()
+			.isEqualTo(TestFactory.createReference());
 	}
 
 	@Test
 	void fromEmptySession() {
 
 		// Act and assert
-		assertThat(LimeMapper.toChatHistoryRequest(null, false, 0, SessionPublic.builder().build())).hasAllNullFieldsOrPropertiesExcept("kundnummer", "isOrganisation", "chatSession")
-			.satisfies(r -> {
-				assertThat(r.getKundnummer()).isEqualTo("0");
-				assertThat(r.getIsOrganisation()).isFalse();
-			})
+		assertThat(LimeMapper.toChatHistoryRequest(null, null, SessionPublic.builder().build())).hasAllNullFieldsOrPropertiesExcept("chatSession")
 			.extracting(ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikSkapaChathistorikRequest::getChatSession).hasAllNullFieldsOrPropertiesExcept("messages")
 			.extracting(ServanetItOpsApiGatewayAdapterHttpContractsModelsRequestsChathistorikChatSessionDto::getMessages).satisfies(l -> assertThat(l).isEmpty());
 	}
@@ -107,6 +152,6 @@ class LimeMapperTest {
 	void fromNull() {
 
 		// Act and assert
-		assertThat(LimeMapper.toChatHistoryRequest(null, false, 0, null)).isNull();
+		assertThat(LimeMapper.toChatHistoryRequest(null, null, null)).isNull();
 	}
 }

--- a/src/test/java/se/sundsvall/selfserviceai/service/AssistantServiceTest.java
+++ b/src/test/java/se/sundsvall/selfserviceai/service/AssistantServiceTest.java
@@ -9,7 +9,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -45,6 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
+import se.sundsvall.dept44.requestid.RequestId;
 import se.sundsvall.selfserviceai.api.model.SessionRequest;
 import se.sundsvall.selfserviceai.integration.agreement.AgreementIntegration;
 import se.sundsvall.selfserviceai.integration.db.FileRepository;
@@ -55,9 +58,11 @@ import se.sundsvall.selfserviceai.integration.installedbase.InstalledbaseIntegra
 import se.sundsvall.selfserviceai.integration.intric.IntricIntegration;
 import se.sundsvall.selfserviceai.integration.intric.configuration.IntricProperties;
 import se.sundsvall.selfserviceai.integration.intric.model.AskResponse;
+import se.sundsvall.selfserviceai.integration.intric.model.SessionPublic;
 import se.sundsvall.selfserviceai.integration.intric.model.filecontent.Facility;
 import se.sundsvall.selfserviceai.integration.intric.model.filecontent.InstalledBase;
 import se.sundsvall.selfserviceai.integration.invoices.InvoicesIntegration;
+import se.sundsvall.selfserviceai.integration.lime.LimeIntegration;
 import se.sundsvall.selfserviceai.integration.measurementdata.MeasurementDataIntegration;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,6 +72,7 @@ class AssistantServiceTest {
 	private static final String ASSISTANT_ID = "assistantId";
 	private static final UUID SESSION_ID = UUID.randomUUID();
 	private static final String PARTY_ID = UUID.randomUUID().toString();
+	private static final String CUSTOMER_NBR = "customerNbr";
 	private static final String FACILITY_ID = UUID.randomUUID().toString();
 	private static final String CUSTOMER_ENGAGEMENT_ORG_ID = "customerEngagementOrgId";
 
@@ -84,6 +90,9 @@ class AssistantServiceTest {
 
 	@Mock
 	private InvoicesIntegration invoicesIntegrationMock;
+
+	@Mock
+	private LimeIntegration limeIntegrationMock;
 
 	@Mock
 	private MeasurementDataIntegration measurementDataIntegrationMock;
@@ -114,6 +123,7 @@ class AssistantServiceTest {
 			agreementIntegrationMock,
 			installedbaseIntegrationMock,
 			invoicesIntegrationMock,
+			limeIntegrationMock,
 			measurementDataIntegrationMock,
 			sessionRepositoryMock,
 			fileRepositoryMock);
@@ -128,18 +138,18 @@ class AssistantServiceTest {
 			.build());
 
 		// Act
-		final var response = assistantService.createSession(MUNICIPALITY_ID);
+		final var response = assistantService.createSession(MUNICIPALITY_ID, PARTY_ID);
 
 		// Assert and verify
 		verify(intricPropertiesMock).assistantId();
-		verify(intricIntegrationMock).askAssistant(ASSISTANT_ID, "Påbörjar session");
+		verify(intricIntegrationMock).askAssistant(ASSISTANT_ID, "Påbörjar session för party id '%s'".formatted(PARTY_ID));
 		verify(sessionRepositoryMock).save(sessionEntityCaptor.capture());
 
 		assertThat(response).isEqualTo(SESSION_ID);
 		assertThat(sessionEntityCaptor.getValue().getCreated()).isNull();
 		assertThat(sessionEntityCaptor.getValue().getFiles()).isEmpty();
 		assertThat(sessionEntityCaptor.getValue().getInitialized()).isNull();
-		assertThat(sessionEntityCaptor.getValue().getInitiationStatus()).isNull();
+		assertThat(sessionEntityCaptor.getValue().getStatus()).isNull();
 		assertThat(sessionEntityCaptor.getValue().getLastAccessed()).isNull();
 		assertThat(sessionEntityCaptor.getValue().getMunicipalityId()).isEqualTo(MUNICIPALITY_ID);
 		assertThat(sessionEntityCaptor.getValue().getSessionId()).isEqualTo(SESSION_ID.toString());
@@ -154,11 +164,11 @@ class AssistantServiceTest {
 		when(intricIntegrationMock.askAssistant(eq(ASSISTANT_ID), anyString())).thenThrow(exception);
 
 		// Act
-		final var e = assertThrows(ThrowableProblem.class, () -> assistantService.createSession(MUNICIPALITY_ID));
+		final var e = assertThrows(ThrowableProblem.class, () -> assistantService.createSession(MUNICIPALITY_ID, PARTY_ID));
 
 		// Assert and verify
 		verify(intricPropertiesMock).assistantId();
-		verify(intricIntegrationMock).askAssistant(ASSISTANT_ID, "Påbörjar session");
+		verify(intricIntegrationMock).askAssistant(ASSISTANT_ID, "Påbörjar session för party id '%s'".formatted(PARTY_ID));
 
 		assertThat(e).isSameAs(exception);
 	}
@@ -232,7 +242,7 @@ class AssistantServiceTest {
 		assertThat(sessionEntityCaptor.getValue()).satisfies(entity -> {
 			assertThat(entity.getFiles()).hasSize(1).extracting(FileEntity::getFileId).containsExactly(fileId.toString());
 			assertThat(entity.getInitialized()).isCloseTo(OffsetDateTime.now(), within(2, SECONDS));
-			assertThat(entity.getInitiationStatus()).isEqualTo("Successfully initialized");
+			assertThat(entity.getStatus()).isEqualTo("Successfully initialized");
 
 			assertListcontent(agreements, invoices, measurementDatas);
 		});
@@ -268,6 +278,7 @@ class AssistantServiceTest {
 	@Test
 	void populateWithInformationWhenNoInstalledbaseResponse() {
 		// Arrange
+		RequestId.init();
 		Problem.valueOf(Status.I_AM_A_TEAPOT, "Big and stout");
 		final var sessionEntity = SessionEntity.builder()
 			.withMunicipalityId(MUNICIPALITY_ID)
@@ -291,13 +302,14 @@ class AssistantServiceTest {
 		assertThat(sessionEntityCaptor.getValue()).satisfies(entity -> {
 			assertThat(entity.getFiles()).isEmpty();
 			assertThat(entity.getInitialized()).isNull();
-			assertThat(entity.getInitiationStatus()).isEqualTo("Initialization failed");
+			assertThat(entity.getStatus()).isEqualTo("Initialization failed, filter logs on log id '%s' for more information".formatted(RequestId.get()));
 		});
 	}
 
 	@Test
 	void populateWithInformationWhenIntricThrowsException() {
 		// Arrange
+		RequestId.init();
 		final var exception = Problem.valueOf(Status.I_AM_A_TEAPOT, "Big and stout");
 		final var sessionEntity = SessionEntity.builder()
 			.withMunicipalityId(MUNICIPALITY_ID)
@@ -326,7 +338,7 @@ class AssistantServiceTest {
 		assertThat(sessionEntityCaptor.getValue()).satisfies(entity -> {
 			assertThat(entity.getFiles()).isEmpty();
 			assertThat(entity.getInitialized()).isNull();
-			assertThat(entity.getInitiationStatus()).isEqualTo("Initialization failed");
+			assertThat(entity.getStatus()).isEqualTo("Initialization failed, filter logs on log id '%s' for more information".formatted(RequestId.get()));
 		});
 	}
 
@@ -478,13 +490,17 @@ class AssistantServiceTest {
 			.withFileId(fileId.toString())
 			.build();
 		final var sessionEntity = SessionEntity.builder()
+			.withCustomerNbr(CUSTOMER_NBR)
 			.withSessionId(SESSION_ID.toString())
 			.withInitialized(OffsetDateTime.now())
 			.withFiles(new ArrayList<>(List.of(fileEntity)))
+			.withPartyId(PARTY_ID)
 			.build();
+		final var session = SessionPublic.builder().build();
 
 		when(intricPropertiesMock.assistantId()).thenReturn(ASSISTANT_ID);
 		when(sessionRepositoryMock.findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID)).thenReturn(Optional.of(sessionEntity));
+		when(intricIntegrationMock.getSession(ASSISTANT_ID, SESSION_ID.toString())).thenReturn(session);
 		when(intricIntegrationMock.deleteFile(fileId.toString())).thenReturn(true);
 		when(intricIntegrationMock.deleteSession(ASSISTANT_ID, SESSION_ID.toString())).thenReturn(true);
 
@@ -493,7 +509,8 @@ class AssistantServiceTest {
 
 		// Assert and verify
 		verify(sessionRepositoryMock).findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID);
-		verify(intricPropertiesMock).assistantId();
+		verify(intricPropertiesMock, times(2)).assistantId();
+		verify(limeIntegrationMock).saveChatHistory(PARTY_ID, CUSTOMER_NBR, session);
 		verify(intricIntegrationMock).deleteFile(fileId.toString());
 		verify(fileRepositoryMock).delete(fileEntity);
 		verify(intricIntegrationMock).deleteSession(ASSISTANT_ID, SESSION_ID.toString());
@@ -504,12 +521,16 @@ class AssistantServiceTest {
 	void deleteSessionWithoutFiles() {
 		// Arrange
 		final var sessionEntity = SessionEntity.builder()
+			.withCustomerNbr(CUSTOMER_NBR)
 			.withSessionId(SESSION_ID.toString())
 			.withInitialized(OffsetDateTime.now())
+			.withPartyId(PARTY_ID)
 			.build();
+		final var session = SessionPublic.builder().build();
 
 		when(intricPropertiesMock.assistantId()).thenReturn(ASSISTANT_ID);
 		when(sessionRepositoryMock.findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID)).thenReturn(Optional.of(sessionEntity));
+		when(intricIntegrationMock.getSession(ASSISTANT_ID, SESSION_ID.toString())).thenReturn(session);
 		when(intricIntegrationMock.deleteSession(ASSISTANT_ID, SESSION_ID.toString())).thenReturn(true);
 
 		// Act
@@ -517,46 +538,29 @@ class AssistantServiceTest {
 
 		// Assert and verify
 		verify(sessionRepositoryMock).findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID);
-		verify(intricPropertiesMock).assistantId();
+		verify(intricPropertiesMock, times(2)).assistantId();
+		verify(limeIntegrationMock).saveChatHistory(PARTY_ID, CUSTOMER_NBR, session);
 		verify(intricIntegrationMock).deleteSession(ASSISTANT_ID, SESSION_ID.toString());
 		verify(sessionRepositoryMock).delete(sessionEntity);
 	}
 
 	@Test
-	void deleteSessionWhenFilesNotSuccessfullyDeleted() {
+	void deleteSessionWhenHistoryNotSuccessfullySaved() {
 		// Arrange
-		final var fileId = UUID.randomUUID();
-		final var fileEntity = FileEntity.builder()
-			.withFileId(fileId.toString())
-			.build();
+		RequestId.init();
 		final var sessionEntity = SessionEntity.builder()
+			.withCustomerNbr(CUSTOMER_NBR)
 			.withSessionId(SESSION_ID.toString())
 			.withInitialized(OffsetDateTime.now())
-			.withFiles(new ArrayList<>(List.of(fileEntity)))
+			.withPartyId(PARTY_ID)
 			.build();
-
-		when(sessionRepositoryMock.findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID)).thenReturn(Optional.of(sessionEntity));
-
-		// Act
-		assistantService.deleteSessionById(MUNICIPALITY_ID, SESSION_ID);
-
-		// Assert and verify
-		verify(sessionRepositoryMock).findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID);
-		verify(intricIntegrationMock).deleteFile(fileId.toString());
-		verify(fileRepositoryMock, never()).delete(fileEntity);
-		verify(sessionRepositoryMock, never()).delete(sessionEntity);
-	}
-
-	@Test
-	void deleteSessionWhenSessionNotSuccessfullyDeleted() {
-		// Arrange
-		final var sessionEntity = SessionEntity.builder()
-			.withSessionId(SESSION_ID.toString())
-			.withInitialized(OffsetDateTime.now())
-			.build();
+		final var session = SessionPublic.builder().build();
+		final var exception = Problem.valueOf(Status.I_AM_A_TEAPOT, "Big and stout");
 
 		when(intricPropertiesMock.assistantId()).thenReturn(ASSISTANT_ID);
 		when(sessionRepositoryMock.findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID)).thenReturn(Optional.of(sessionEntity));
+		when(intricIntegrationMock.getSession(ASSISTANT_ID, SESSION_ID.toString())).thenReturn(session);
+		doThrow(exception).when(limeIntegrationMock).saveChatHistory(PARTY_ID, CUSTOMER_NBR, session);
 
 		// Act
 		assistantService.deleteSessionById(MUNICIPALITY_ID, SESSION_ID);
@@ -564,8 +568,74 @@ class AssistantServiceTest {
 		// Assert and verify
 		verify(sessionRepositoryMock).findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID);
 		verify(intricPropertiesMock).assistantId();
+		verify(limeIntegrationMock).saveChatHistory(PARTY_ID, CUSTOMER_NBR, session);
+
+		assertThat(sessionEntity.getStatus()).isEqualTo("Failed to save chat history, filter logs on log id '%s' for more information".formatted(RequestId.get()));
+	}
+
+	@Test
+	void deleteSessionWhenFilesNotSuccessfullyDeleted() {
+		// Arrange
+		RequestId.init();
+		final var fileId = UUID.randomUUID();
+		final var fileEntity = FileEntity.builder()
+			.withFileId(fileId.toString())
+			.build();
+		final var sessionEntity = SessionEntity.builder()
+			.withCustomerNbr(CUSTOMER_NBR)
+			.withSessionId(SESSION_ID.toString())
+			.withInitialized(OffsetDateTime.now())
+			.withFiles(new ArrayList<>(List.of(fileEntity)))
+			.withPartyId(PARTY_ID)
+			.build();
+		final var session = SessionPublic.builder().build();
+
+		when(intricPropertiesMock.assistantId()).thenReturn(ASSISTANT_ID);
+		when(sessionRepositoryMock.findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID)).thenReturn(Optional.of(sessionEntity));
+		when(intricIntegrationMock.getSession(ASSISTANT_ID, SESSION_ID.toString())).thenReturn(session);
+
+		// Act
+		assistantService.deleteSessionById(MUNICIPALITY_ID, SESSION_ID);
+
+		// Assert and verify
+		verify(sessionRepositoryMock).findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID);
+		verify(intricPropertiesMock).assistantId();
+		verify(limeIntegrationMock).saveChatHistory(PARTY_ID, CUSTOMER_NBR, session);
+		verify(intricIntegrationMock).deleteFile(fileId.toString());
+		verify(fileRepositoryMock, never()).delete(fileEntity);
+		verify(sessionRepositoryMock, never()).delete(sessionEntity);
+
+		assertThat(sessionEntity.getStatus()).isEqualTo("Failed to delete session, filter logs on log id '%s' for more information".formatted(RequestId.get()));
+	}
+
+	@Test
+	void deleteSessionWhenSessionNotSuccessfullyDeleted() {
+		// Arrange
+		RequestId.init();
+		final var sessionEntity = SessionEntity.builder()
+			.withCustomerNbr(CUSTOMER_NBR)
+			.withSessionId(SESSION_ID.toString())
+			.withInitialized(OffsetDateTime.now())
+			.withPartyId(PARTY_ID)
+			.build();
+		final var session = SessionPublic.builder().build();
+
+		when(intricPropertiesMock.assistantId()).thenReturn(ASSISTANT_ID);
+		when(sessionRepositoryMock.findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID)).thenReturn(Optional.of(sessionEntity));
+		when(intricIntegrationMock.getSession(ASSISTANT_ID, SESSION_ID.toString())).thenReturn(session);
+
+		// Act
+		assistantService.deleteSessionById(MUNICIPALITY_ID, SESSION_ID);
+
+		// Assert and verify
+		verify(sessionRepositoryMock).findBySessionIdAndMunicipalityId(SESSION_ID.toString(), MUNICIPALITY_ID);
+		verify(intricPropertiesMock, times(2)).assistantId();
+		verify(intricIntegrationMock).getSession(ASSISTANT_ID, SESSION_ID.toString());
+		verify(limeIntegrationMock).saveChatHistory(PARTY_ID, CUSTOMER_NBR, session);
 		verify(intricIntegrationMock).deleteSession(ASSISTANT_ID, SESSION_ID.toString());
 		verify(sessionRepositoryMock, never()).delete(sessionEntity);
+
+		assertThat(sessionEntity.getStatus()).isEqualTo("Failed to delete session, filter logs on log id '%s' for more information".formatted(RequestId.get()));
 	}
 
 	@Test
@@ -591,9 +661,10 @@ class AssistantServiceTest {
 		final var inactiveThreshold = 10;
 		final var sessionId = UUID.randomUUID();
 		final var fileId = UUID.randomUUID();
-
+		final var session = SessionPublic.builder().build();
 		// Arrange
 		when(intricPropertiesMock.assistantId()).thenReturn(ASSISTANT_ID);
+		when(intricIntegrationMock.getSession(ASSISTANT_ID, sessionId.toString())).thenReturn(session);
 		when(intricIntegrationMock.deleteFile(any())).thenReturn(true);
 		when(intricIntegrationMock.deleteSession(any(), any())).thenReturn(true);
 		when(sessionRepositoryMock.findAllByLastAccessedBeforeOrLastAccessedIsNull(any())).thenReturn(List.of(
@@ -611,10 +682,12 @@ class AssistantServiceTest {
 			return true;
 		}));
 
+		verify(limeIntegrationMock).saveChatHistory(PARTY_ID, CUSTOMER_NBR, session);
 		verify(intricIntegrationMock).deleteSession(ASSISTANT_ID, sessionId.toString());
 		verify(intricIntegrationMock).deleteFile(fileId.toString());
 		verify(fileRepositoryMock).delete(fileEntityCaptor.capture());
 		verify(sessionRepositoryMock).delete(sessionEntityCaptor.capture());
+
 		assertThat(fileEntityCaptor.getValue().getFileId()).isEqualTo(fileId.toString());
 		assertThat(sessionEntityCaptor.getValue().getSessionId()).isEqualTo(sessionId.toString());
 	}
@@ -622,12 +695,14 @@ class AssistantServiceTest {
 	private SessionEntity createSession(final UUID sessionId, final UUID fileId, final OffsetDateTime created, final OffsetDateTime lastAccessed) {
 		return SessionEntity.builder()
 			.withCreated(created)
+			.withCustomerNbr(CUSTOMER_NBR)
 			.withLastAccessed(lastAccessed)
 			.withSessionId(sessionId.toString())
 			.withFiles(new ArrayList<>(List.of(
 				FileEntity.builder()
 					.withFileId(fileId.toString())
 					.build())))
+			.withPartyId(PARTY_ID)
 			.build();
 	}
 }

--- a/src/test/resources/db/schema/schema.sql
+++ b/src/test/resources/db/schema/schema.sql
@@ -9,9 +9,11 @@
         created datetime(6),
         initialized datetime(6),
         last_accessed datetime(6),
-        initiation_status mediumtext,
+        customer_nbr varchar(255),
         municipality_id varchar(255) not null,
+        party_id varchar(255) not null,
         session_id varchar(255) not null,
+        status mediumtext,
         primary key (session_id)
     ) engine=InnoDB;
 

--- a/src/test/resources/db/scripts/testdata-it.sql
+++ b/src/test/resources/db/scripts/testdata-it.sql
@@ -1,9 +1,9 @@
-INSERT INTO session(municipality_id, session_id, created, initialized, last_accessed, initiation_status)
-VALUES ('2281', 'a6602aba-0b21-4abf-a869-60c583570129', '2025-01-01 10:00:00', NULL, NULL, NULL), -- Created but has not yet completed its initialization phase
-       ('2281', '4dc21d5e-8a70-45fb-b225-367fcd383a2e', '2025-01-01 11:00:00', '2025-01-01 11:00:30', NULL, 'Successfully initialized'), -- Created and successfully initialized, but not yet accessed
-       ('2281', 'b72af369-1764-486d-8d4d-17158318f6dd', '2025-01-01 13:00:00', '2025-01-01 13:00:30', '2025-01-01 13:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed
-       ('2281', '158cfabe-1c3d-433c-b71f-1c909beaa291', '2025-01-01 12:00:00', '2025-01-01 12:00:30', '2025-01-01 12:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed
-       ('2281', '8212c515-6f7a-4e1c-a6b4-a2e265f018ed', '2025-01-01 14:00:00', NULL, NULL, 'Initialization failed');  -- Created but failed in initialization phase
+INSERT INTO session(municipality_id, session_id, party_id, customer_nbr, created, initialized, last_accessed, status)
+VALUES ('2281', 'a6602aba-0b21-4abf-a869-60c583570129', '52663047-49cd-4f1a-b474-beea8e4eb36f', NULL, '2025-01-01 10:00:00', NULL, NULL, NULL), -- Created but has not yet completed its initialization phase
+       ('2281', '4dc21d5e-8a70-45fb-b225-367fcd383a2e', 'e7d536c8-86a7-4a65-98ce-e700e65e31d7', '16324', '2025-01-01 11:00:00', '2025-01-01 11:00:30', NULL, 'Successfully initialized'), -- Created and successfully initialized, but not yet accessed
+       ('2281', 'b72af369-1764-486d-8d4d-17158318f6dd', 'f6eb1c0c-2919-48f6-b2b6-65a5f636b87b', '24958', '2025-01-01 13:00:00', '2025-01-01 13:00:30', '2025-01-01 13:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed session 1
+       ('2281', '158cfabe-1c3d-433c-b71f-1c909beaa291', '9bb8472c-f528-4ed0-ba12-d5b6548d429e', '11393', '2025-01-01 12:00:00', '2025-01-01 12:00:30', '2025-01-01 12:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed session 2
+       ('2281', '8212c515-6f7a-4e1c-a6b4-a2e265f018ed', 'f6edb8b8-98c4-4427-9495-1713fada3d2d', NULL, '2025-01-01 14:00:00', NULL, NULL, 'Initialization failed');  -- Created but failed in initialization phase
 
 INSERT INTO file(file_id, session_id)
 VALUES ('5ef193cd-96a7-4861-a33d-e01528618f2e', '4dc21d5e-8a70-45fb-b225-367fcd383a2e'), -- file 1 connected to created, initialized but not yet accessed session

--- a/src/test/resources/db/scripts/testdata-junit.sql
+++ b/src/test/resources/db/scripts/testdata-junit.sql
@@ -1,9 +1,9 @@
-INSERT INTO session(municipality_id, session_id, created, initialized, last_accessed, initiation_status)
-VALUES ('2281', 'a6602aba-0b21-4abf-a869-60c583570129', '2025-01-01 10:00:00', NULL, NULL, NULL), -- Created but has not yet completed its initialization phase
-       ('2281', '4dc21d5e-8a70-45fb-b225-367fcd383a2e', '2025-01-01 11:00:00', '2025-01-01 11:00:30', NULL, 'Successfully initialized'), -- Created and successfully initialized, but not yet accessed
-       ('2281', 'b72af369-1764-486d-8d4d-17158318f6dd', '2025-01-01 13:00:00', '2025-01-01 13:00:30', '2025-01-01 13:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed
-       ('2281', '158cfabe-1c3d-433c-b71f-1c909beaa291', '2025-01-01 12:00:00', '2025-01-01 12:00:30', '2025-01-01 12:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed
-       ('2281', '8212c515-6f7a-4e1c-a6b4-a2e265f018ed', '2025-01-01 14:00:00', NULL, NULL, 'Initialization failed');  -- Created but failed in initialization phase
+INSERT INTO session(municipality_id, session_id, party_id, customer_nbr, created, initialized, last_accessed, status)
+VALUES ('2281', 'a6602aba-0b21-4abf-a869-60c583570129', '52663047-49cd-4f1a-b474-beea8e4eb36f', NULL, '2025-01-01 10:00:00', NULL, NULL, NULL), -- Created but has not yet completed its initialization phase
+       ('2281', '4dc21d5e-8a70-45fb-b225-367fcd383a2e', 'e7d536c8-86a7-4a65-98ce-e700e65e31d7', '16324', '2025-01-01 11:00:00', '2025-01-01 11:00:30', NULL, 'Successfully initialized'), -- Created and successfully initialized, but not yet accessed
+       ('2281', 'b72af369-1764-486d-8d4d-17158318f6dd', 'f6eb1c0c-2919-48f6-b2b6-65a5f636b87b', '24958', '2025-01-01 13:00:00', '2025-01-01 13:00:30', '2025-01-01 13:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed session 1
+       ('2281', '158cfabe-1c3d-433c-b71f-1c909beaa291', '9bb8472c-f528-4ed0-ba12-d5b6548d429e', '11393', '2025-01-01 12:00:00', '2025-01-01 12:00:30', '2025-01-01 12:01:00', 'Successfully initialized'), -- Created and successfully initialized and accessed session 2
+       ('2281', '8212c515-6f7a-4e1c-a6b4-a2e265f018ed', 'f6edb8b8-98c4-4427-9495-1713fada3d2d', NULL, '2025-01-01 14:00:00', NULL, NULL, 'Initialization failed');  -- Created but failed in initialization phase
 
 INSERT INTO file(file_id, session_id)
 VALUES ('5ef193cd-96a7-4861-a33d-e01528618f2e', '4dc21d5e-8a70-45fb-b225-367fcd383a2e'), -- file 1 connected to created, initialized but not yet accessed session


### PR DESCRIPTION
- Added logic in service layer to save chat history in Lime
- Extended Intric model to fetch full instance of chat history information
- Modified DB model to store of party id and customer number (required in request to Lime)
- Modified error handling and logging for easier troubleshooting

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
